### PR TITLE
feat(testurl): streamline port handling in URL functions 🌐

### DIFF
--- a/things/testurl/go.mod
+++ b/things/testurl/go.mod
@@ -1,0 +1,3 @@
+module github.com/madflojo/testlazy/things/testurl
+
+go 1.24.3

--- a/things/testurl/url.go
+++ b/things/testurl/url.go
@@ -3,13 +3,7 @@ Package testurl makes URL generation in Go tests a breeze—no more boilerplate
 url.Parse calls or manual query-string concat. Simply import testurl and pick
 the helper you need to focus on your test logic, not the URL plumbing.
 
-  github.com/madflojo/testlazy/things/testurl
-
-What’s inside?
-
-- HTTP vs HTTPS for example.com and localhost.
-- Ports, paths, queries, and fragments.
-- Intentionally broken URLs for negative testing.
+	github.com/madflojo/testlazy/things/testurl
 
 Example usage
 
@@ -30,6 +24,8 @@ import (
 const (
 	ExampleHost   = "example.com"
 	LocalhostHost = "localhost"
+	HTTPPort      = "8080"
+	HTTPSPort     = "8443"
 )
 
 // URLHTTPBad returns a *url.URL for "http://bad-url" which is technically valid but "should" not resolve correctly.
@@ -69,12 +65,12 @@ func URLHTTPS() *url.URL {
 
 // URLHTTPWithPort returns a *url.URL for "http://example.com:8080/".
 func URLHTTPWithPort() *url.URL {
-	return MustParse("http://" + ExampleHost + ":8080/")
+	return MustParse("http://" + ExampleHost + ":" + HTTPPort + "/")
 }
 
 // URLHTTPSWithPort returns a *url.URL for "https://example.com:8443/".
 func URLHTTPSWithPort() *url.URL {
-	return MustParse("https://" + ExampleHost + ":8443/")
+	return MustParse("https://" + ExampleHost + ":" + HTTPSPort + "/")
 }
 
 // URLHTTPWithQuery returns a *url.URL for "http://example.com/?query=1".
@@ -129,12 +125,12 @@ func URLHTTPSLocalhost() *url.URL {
 
 // URLHTTPLocalhostWithPort returns a *url.URL for "http://localhost:8080/".
 func URLHTTPLocalhostWithPort() *url.URL {
-	return MustParse("http://" + LocalhostHost + ":8080/")
+	return MustParse("http://" + LocalhostHost + ":" + HTTPPort + "/")
 }
 
 // URLHTTPSLocalhostWithPort returns a *url.URL for "https://localhost:8443/".
 func URLHTTPSLocalhostWithPort() *url.URL {
-	return MustParse("https://" + LocalhostHost + ":8443/")
+	return MustParse("https://" + LocalhostHost + ":" + HTTPSPort + "/")
 }
 
 // MustParse is a helper function that parses a URL string and panics if it fails.


### PR DESCRIPTION
Introduced constants for HTTP and HTTPS ports to reduce redundancy. Now the URLs sing the same tune sans repetition!

This pull request introduces a new Go module for URL handling and refactors the code to improve maintainability by using constants for port definitions. Additionally, some redundant documentation has been removed to streamline the codebase.

### New module creation:

* [`things/testurl/go.mod`](diffhunk://#diff-d631c20ff70ca5fbf239315720623892ef715302a95121b2da37f47b8c00e528R1-R3): Added a new Go module definition for `github.com/madflojo/testlazy/things/testurl` with Go version `1.24.3`.

### Code refactoring for maintainability:

* [`things/testurl/url.go`](diffhunk://#diff-ad9f997c72bd3587d22e4e50c0f5ee3ef505e3a8dff2c8be0ba840f5085cb7b2R27-R28): Introduced constants `HTTPPort` and `HTTPSPort` to replace hardcoded port values in URL generation functions. Updated functions like `URLHTTPWithPort`, `URLHTTPSWithPort`, `URLHTTPLocalhostWithPort`, and `URLHTTPSLocalhostWithPort` to use these constants. [[1]](diffhunk://#diff-ad9f997c72bd3587d22e4e50c0f5ee3ef505e3a8dff2c8be0ba840f5085cb7b2R27-R28) [[2]](diffhunk://#diff-ad9f997c72bd3587d22e4e50c0f5ee3ef505e3a8dff2c8be0ba840f5085cb7b2L72-R73) [[3]](diffhunk://#diff-ad9f997c72bd3587d22e4e50c0f5ee3ef505e3a8dff2c8be0ba840f5085cb7b2L132-R133)

### Documentation cleanup:

* [`things/testurl/url.go`](diffhunk://#diff-ad9f997c72bd3587d22e4e50c0f5ee3ef505e3a8dff2c8be0ba840f5085cb7b2L8-L13): Removed redundant documentation describing HTTP vs HTTPS, ports, paths, queries, and fragments to simplify the file.