### PR TITLE
ci(workflow): fix workflow permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,6 @@
 name: Lint Commit Messages
+permissions:
+  contents: read
 
 on: [pull_request]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/madflojo/testlazy/security/code-scanning/6](https://github.com/madflojo/testlazy/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block at the appropriate level in the workflow YAML file to restrict the default permissions of the `GITHUB_TOKEN` to the minimum required. Since none of the steps in the `commitlint` job require write access, we can safely set `permissions: contents: read`, either at the root (applies to all jobs), or under the job (`commitlint:`) (scoped to just this job). Best practice is usually to do this at the root unless there are jobs with differing requirements. We will add the following block after the `name` field, before the `on` field:

```yaml
permissions:
  contents: read
```

No imports, definitions, or further code are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
